### PR TITLE
Added support for escaping &/% in tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "md2tex"
-version = "0.1.3"
-authors = ["lbeckman314 <liam@liambeckman.com>"]
+version = "0.1.4"
+authors = ["lbeckman314 <liam@liambeckman.com>", "Sebastian Steiner <sebastian.steiner@tuta.io>"]
 description = "A small utility to convert markdown files to pdf exploiting tectonic. This is a forked version based off of tforgione's awesome library (https://gitea.tforgione.fr/tforgione/md2pdf/)."
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ pub fn markdown_to_tex(markdown: String) -> String {
 
                 output.push_str("\\begin{figure}\n");
                 output.push_str("\\centering\n");
-                output.push_str("\\includegraphics[width=\\textwidth]{");;
+                output.push_str("\\includegraphics[width=\\textwidth]{");
                 output.push_str(&format!("../../src/{path}", path = path_str));
                 output.push_str("}\n");
                 output.push_str("\\caption{");
@@ -343,6 +343,7 @@ pub fn markdown_to_tex(markdown: String) -> String {
                 let delim_start = vec![r"\(", r"\["];
                 let delim_end = vec![r"\)", r"\]"];
 
+
                 if buffer.len() > 100 {
                     buffer.clear();
                 }
@@ -355,7 +356,8 @@ pub fn markdown_to_tex(markdown: String) -> String {
                     EventType::Strong
                     | EventType::Emphasis
                     | EventType::Text
-                    | EventType::Header => {
+                    | EventType::Header
+                    | EventType::Table => {
                         // TODO more elegant way to do ordered `replace`s (structs?).
                         if delim_start
                             .into_iter()
@@ -386,7 +388,7 @@ pub fn markdown_to_tex(markdown: String) -> String {
                                     .replace(r"\w", r"\textbackslash{}w")
                                     .replace("_", r"\_")
                                     .replace(r"\<", "<")
-                                    .replace(r"%", "%")
+                                    .replace(r"%", r"\%")
                                     .replace(r"$", r"\$")
                                     .replace(r"—", "---")
                                     .replace("#", r"\#"),


### PR DESCRIPTION
Hi, I noticed that some characters are not always properly escaped, like & and % in tables. This PR should fix that issue and also generally escapes the & character in regular code. It would be great if you could merge this into md2tex.

If you want to discuss this, just message me.